### PR TITLE
Setting up proxies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "se701-frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5001",
   "dependencies": {
     "@babel/core": "^7.7.4",
     "@babel/runtime": "^7.7.2",

--- a/frontend/static.json
+++ b/frontend/static.json
@@ -1,0 +1,11 @@
+{
+    "root": "build/",
+    "routes": {
+      "/**": "index.html"
+    },
+    "proxies": {
+      "/api/": {
+        "origin": "${API_URL}"
+      }
+    }
+  }

--- a/frontend/static.json
+++ b/frontend/static.json
@@ -1,11 +1,11 @@
 {
-    "root": "build/",
-    "routes": {
-      "/**": "index.html"
-    },
-    "proxies": {
-      "/api/": {
-        "origin": "${API_URL}"
-      }
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  },
+  "proxies": {
+    "/api/": {
+      "origin": "${API_URL}"
     }
   }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const app = require('./app');
 const db = require('./src/db');
 
-const port = 5001;
+const port = process.env.PORT || 5001;
 
 db.connect().then(() => {
   app.listen(port, () => {


### PR DESCRIPTION
Fixes #60, Fixes #61

## Proposed Changes

  - Fixed port configuration
  - Set up development proxy for API calls to be sent to `localhost:5001`
  - Set up deployment proxy for API calls to be sent to the API server
