### PR TITLE
Change backend to reflect specification

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,7 +9,7 @@ app.use(express.json());
 
 const postsRouter = require('./src/routes/posts');
 
-app.use('/api/post', postsRouter);
+app.use('/api/posts', postsRouter);
 
 app.get('/', (req, res) => res.send('Hello World!'));
 

--- a/server/app.js
+++ b/server/app.js
@@ -9,7 +9,7 @@ app.use(express.json());
 
 const postsRouter = require('./src/routes/posts');
 
-app.use('/posts', postsRouter);
+app.use('/api/post', postsRouter);
 
 app.get('/', (req, res) => res.send('Hello World!'));
 

--- a/server/src/db/models/comments.js
+++ b/server/src/db/models/comments.js
@@ -12,7 +12,7 @@ const commentsSchema = new mongoose.Schema(
     },
   },
   {
-    timestamps: true,
+    timestamps: { createdAt: 'date_created' },
   },
 );
 

--- a/server/src/db/models/comments.js
+++ b/server/src/db/models/comments.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const commentsSchema = new mongoose.Schema(
   {
-    comment_id: {
+    children_id: {
       type: String,
       required: false,
     },

--- a/server/src/db/models/post.js
+++ b/server/src/db/models/post.js
@@ -27,7 +27,7 @@ const postSchema = new mongoose.Schema(
     },
   },
   {
-    timestamps: true,
+    timestamps: { createdAt: 'date_created' },
   },
 );
 

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -52,7 +52,7 @@ router.get('/:id', async (req, res) => {
       upvotes_clap: foundPost.upvotes_clap,
       upvotes_laugh: foundPost.upvotes_laugh,
       upvotes_sad: foundPost.upvotes_sad,
-      date_created: foundPost.createdAt,
+      date_created: foundPost.date_created,
       comments: await Comment.find({ _id: { $in: foundPost.comment_id } }),
     };
 

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -79,7 +79,7 @@ router.delete('/:id', async (req, res) => {
 // eslint-disable-next-line no-unused-vars
 router.post('/:id/comment', async (req, res) => {
   const comment = new Comment({
-    comment_id: req.body.comment_id,
+    children_id: req.body.children_id,
     body: req.body.body,
   });
   try {

--- a/server/test/integration/post.spec.js
+++ b/server/test/integration/post.spec.js
@@ -32,7 +32,7 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(201);
@@ -53,7 +53,7 @@ describe('Posts API', () => {
     const postData = {};
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(400);
@@ -68,13 +68,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/posts');
+    const response2 = await supertest(app).get('/api/post');
 
     // Upvote the post
     const upvoteRequest = {
@@ -84,12 +84,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/posts/${response2.body[0]._id}/upvote`)
+      .put(`/api/post/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(200);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/posts');
+    const response4 = await supertest(app).get('/api/post');
     expect(response4.body[0].upvotes_clap).toBe(1);
     done();
   });
@@ -102,7 +102,7 @@ describe('Posts API', () => {
     };
 
     const response1 = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
     expect(response1.status).toBe(201);
 
@@ -112,7 +112,7 @@ describe('Posts API', () => {
       body: 'Second Body',
     };
 
-    const url = '/posts/';
+    const url = '/api/post/';
     const response2 = await supertest(app)
       .put(url.concat(response1.body._id))
       .send({ title: updatedPost.title, body: updatedPost.body });
@@ -133,7 +133,7 @@ describe('Posts API', () => {
       body: 'Second Body',
     };
 
-    const url = '/posts/';
+    const url = '/api/post/';
     const response2 = await supertest(app)
       .put(url.concat('100'))
       .send({ title: updatedPost.title, body: updatedPost.body });
@@ -149,12 +149,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/posts');
+    const response2 = await supertest(app).get('/api/post');
 
     // Upvote the post
     const upvoteRequest = {
@@ -164,12 +164,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/posts/${response2.body[0]._id}/upvote`)
+      .put(`/api/post/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(400);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/posts');
+    const response4 = await supertest(app).get('/api/post');
     expect(response4.body[0].upvotes_clap).toBe(0);
     done();
   });
@@ -182,11 +182,11 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
     expect(response.status).toBe(201);
     const createdPost = response.body;
-    const url = '/posts/';
+    const url = '/api/post/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id));
 
@@ -206,12 +206,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/posts');
+    const response2 = await supertest(app).get('/api/post');
 
     // Downvote the post
     const upvoteRequest = {
@@ -221,12 +221,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/posts/${response2.body[0]._id}/upvote`)
+      .put(`/api/post/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(200);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/posts');
+    const response4 = await supertest(app).get('/api/post');
     expect(response4.body[0].upvotes_clap).toBe(-1);
     done();
   });
@@ -239,12 +239,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(201);
     const createdPost = response.body;
-    const url = '/posts/';
+    const url = '/api/post/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id));
 
@@ -267,7 +267,7 @@ describe('Posts API', () => {
   it('tests the delete route with no defined post id', async done => {
     const postData = {};
 
-    const url = '/posts/';
+    const url = '/api/post/';
 
     const response = await supertest(app).delete(url.concat(postData));
 
@@ -282,11 +282,11 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     const createdPost = response.body;
-    const url = '/posts/';
+    const url = '/api/post/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id + 3));
 
@@ -301,13 +301,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     const createdPost = response.body;
-    const url = '/posts/';
+    const url = '/api/post/';
     const commentData = {
       body: 'This is the body for a test comment',
     };
@@ -340,13 +340,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/posts')
+      .post('/api/post')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     const createdPost = response.body;
-    const url = '/posts/';
+    const url = '/api/post/';
     const commentData = {
       body: 'This is the body for a test comment',
     };
@@ -404,7 +404,7 @@ describe('Posts API', () => {
   //   };
 
   //   const response = await supertest(app)
-  //     .post('/posts/:id/comments')
+  //     .post('/api/post/:id/comments')
   //     .send(commentData);
 
   //   expect(response1.status).toBe(201);

--- a/server/test/integration/post.spec.js
+++ b/server/test/integration/post.spec.js
@@ -329,7 +329,7 @@ describe('Posts API', () => {
     expect(response2.body.upvotes_sad).toBe(0);
     expect(response2.body.comments[0]._id).toBeDefined();
     expect(response2.body.comments[0].body).toBe(commentData.body);
-    expect(response2.body.comments[0].createdAt).toBeDefined();
+    expect(response2.body.comments[0].date_created).toBeDefined();
     done();
   });
 
@@ -371,7 +371,7 @@ describe('Posts API', () => {
     expect(response2.body.upvotes_sad).toBe(0);
     expect(response2.body.comments[0]._id).toBeDefined();
     expect(response2.body.comments[0].body).toBe(commentData.body);
-    expect(response2.body.comments[0].createdAt).toBeDefined();
+    expect(response2.body.comments[0].date_created).toBeDefined();
 
     const response3 = await supertest(app)
       .post(url.concat(createdPost._id, '/comment'))
@@ -390,10 +390,10 @@ describe('Posts API', () => {
     expect(response4.body.upvotes_sad).toBe(0);
     expect(response4.body.comments[0]._id).toBeDefined();
     expect(response4.body.comments[0].body).toBe(commentData.body);
-    expect(response4.body.comments[0].createdAt).toBeDefined();
+    expect(response4.body.comments[0].date_created).toBeDefined();
     expect(response4.body.comments[1]._id).toBeDefined();
     expect(response4.body.comments[1].body).toBe(commentData2.body);
-    expect(response4.body.comments[1].createdAt).toBeDefined();
+    expect(response4.body.comments[1].date_created).toBeDefined();
     done();
   });
 

--- a/server/test/integration/post.spec.js
+++ b/server/test/integration/post.spec.js
@@ -32,7 +32,7 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(201);
@@ -53,7 +53,7 @@ describe('Posts API', () => {
     const postData = {};
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(400);
@@ -68,13 +68,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/api/post');
+    const response2 = await supertest(app).get('/api/posts');
 
     // Upvote the post
     const upvoteRequest = {
@@ -84,12 +84,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/api/post/${response2.body[0]._id}/upvote`)
+      .put(`/api/posts/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(200);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/api/post');
+    const response4 = await supertest(app).get('/api/posts');
     expect(response4.body[0].upvotes_clap).toBe(1);
     done();
   });
@@ -102,7 +102,7 @@ describe('Posts API', () => {
     };
 
     const response1 = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
     expect(response1.status).toBe(201);
 
@@ -112,7 +112,7 @@ describe('Posts API', () => {
       body: 'Second Body',
     };
 
-    const url = '/api/post/';
+    const url = '/api/posts/';
     const response2 = await supertest(app)
       .put(url.concat(response1.body._id))
       .send({ title: updatedPost.title, body: updatedPost.body });
@@ -133,7 +133,7 @@ describe('Posts API', () => {
       body: 'Second Body',
     };
 
-    const url = '/api/post/';
+    const url = '/api/posts/';
     const response2 = await supertest(app)
       .put(url.concat('100'))
       .send({ title: updatedPost.title, body: updatedPost.body });
@@ -149,12 +149,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/api/post');
+    const response2 = await supertest(app).get('/api/posts');
 
     // Upvote the post
     const upvoteRequest = {
@@ -164,12 +164,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/api/post/${response2.body[0]._id}/upvote`)
+      .put(`/api/posts/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(400);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/api/post');
+    const response4 = await supertest(app).get('/api/posts');
     expect(response4.body[0].upvotes_clap).toBe(0);
     done();
   });
@@ -182,11 +182,11 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
     expect(response.status).toBe(201);
     const createdPost = response.body;
-    const url = '/api/post/';
+    const url = '/api/posts/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id));
 
@@ -206,12 +206,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
     expect(response.status).toBe(201);
 
     // Get post
-    const response2 = await supertest(app).get('/api/post');
+    const response2 = await supertest(app).get('/api/posts');
 
     // Downvote the post
     const upvoteRequest = {
@@ -221,12 +221,12 @@ describe('Posts API', () => {
     };
 
     const response3 = await supertest(app)
-      .put(`/api/post/${response2.body[0]._id}/upvote`)
+      .put(`/api/posts/${response2.body[0]._id}/upvote`)
       .send(upvoteRequest);
     expect(response3.status).toBe(200);
 
     // Check if post was upvoted
-    const response4 = await supertest(app).get('/api/post');
+    const response4 = await supertest(app).get('/api/posts');
     expect(response4.body[0].upvotes_clap).toBe(-1);
     done();
   });
@@ -239,12 +239,12 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(201);
     const createdPost = response.body;
-    const url = '/api/post/';
+    const url = '/api/posts/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id));
 
@@ -267,7 +267,7 @@ describe('Posts API', () => {
   it('tests the delete route with no defined post id', async done => {
     const postData = {};
 
-    const url = '/api/post/';
+    const url = '/api/posts/';
 
     const response = await supertest(app).delete(url.concat(postData));
 
@@ -282,11 +282,11 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     const createdPost = response.body;
-    const url = '/api/post/';
+    const url = '/api/posts/';
 
     const response1 = await supertest(app).delete(url.concat(createdPost._id + 3));
 
@@ -301,13 +301,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     const createdPost = response.body;
-    const url = '/api/post/';
+    const url = '/api/posts/';
     const commentData = {
       body: 'This is the body for a test comment',
     };
@@ -340,13 +340,13 @@ describe('Posts API', () => {
     };
 
     const response = await supertest(app)
-      .post('/api/post')
+      .post('/api/posts')
       .send(postData);
 
     expect(response.status).toBe(201);
 
     const createdPost = response.body;
-    const url = '/api/post/';
+    const url = '/api/posts/';
     const commentData = {
       body: 'This is the body for a test comment',
     };
@@ -404,7 +404,7 @@ describe('Posts API', () => {
   //   };
 
   //   const response = await supertest(app)
-  //     .post('/api/post/:id/comments')
+  //     .post('/api/posts/:id/comments')
   //     .send(commentData);
 
   //   expect(response1.status).toBe(201);

--- a/server/test/model/post.spec.js
+++ b/server/test/model/post.spec.js
@@ -41,7 +41,7 @@ describe('Post Model', () => {
     expect(savedPost.upvotes_sad).toBe(0);
 
     // time stamps set
-    expect(savedPost.createdAt).toBeDefined();
+    expect(savedPost.date_created).toBeDefined();
     expect(savedPost.updatedAt).toBeDefined();
 
     done();


### PR DESCRIPTION
Fixes #90 

## Proposed Changes

  -Add '/api' prefix to endpoints and change '/api/post' to plural, '/api/posts'
  -Change timestamps to use 'date_created' parameter name instead of 'createdAt'
  -Change Comment Schema to use 'children_id' instead of 'comment_id'
