### PR TITLE
Change frontend so that routes reflect the API specification

### DIFF
--- a/frontend/src/pages/CreatePost/withCreatePostService.test.js
+++ b/frontend/src/pages/CreatePost/withCreatePostService.test.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { render, wait }  from '@testing-library/react';
+import { render, wait } from '@testing-library/react';
 import { createPostService } from './withCreatePostService';
 import { SubmitPostError } from '../../services/createPostService';
 
@@ -12,7 +12,6 @@ const MockCreatePost = ({ errorMessage, onSubmit }) => {
 
 describe('withCreatePostService', () => {
   it('renders the wrapped component', async () => {
-
     const mockSubmitPost = () => {};
     const CreatePostServiced = createPostService(mockSubmitPost)(MockCreatePost);
     const { getByText } = render(<CreatePostServiced showModal setModal={() => {}} />);

--- a/frontend/src/pages/PostDetail/PostDetailPage.jsx
+++ b/frontend/src/pages/PostDetail/PostDetailPage.jsx
@@ -57,7 +57,7 @@ const PostDetailPage = ({
             <Container maxWidth="sm" key={`${Math.floor(Math.random() * 100)}-container-key`}>
               <Comment
                 body={comment.body}
-                dateCreated={formatDate(comment.createdAt)}
+                dateCreated={formatDate(comment.date_created)}
                 setModal={() => {
                   setModal(true);
                 }}

--- a/frontend/src/pages/PostDetail/PostDetailPageContainer.jsx
+++ b/frontend/src/pages/PostDetail/PostDetailPageContainer.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { getPostInformation } from '../../services/PostDetailService';
+import { getPostInformation } from '../../services/postDetailService';
 import { handleVote } from '../../services/frontpageService';
 
 const PostDetailPageContainer = ({ children }) => {

--- a/frontend/src/pages/PostDetail/withCreateCommentService.jsx
+++ b/frontend/src/pages/PostDetail/withCreateCommentService.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import submitComment, { SubmitCommentError } from '../../services/PostDetailService';
+import submitComment, { SubmitCommentError } from '../../services/postDetailService';
 
 export const createCommentService = submit => CreateCommentModal => ({
   showModal,

--- a/frontend/src/services/apiRoutes.js
+++ b/frontend/src/services/apiRoutes.js
@@ -1,0 +1,9 @@
+const API_ROOT = '/api';
+
+export const upvotePostRoute = id => `${API_ROOT}/posts/${id}/upvote`;
+export const getPostsRoute = `${API_ROOT}/posts`;
+export const createPostRoute = getPostsRoute;
+export const getPostRoute = id => `${API_ROOT}/api/posts/${id}`;
+export const updatePostRoute = id => `${API_ROOT}/api/posts/${id}`;
+export const getCommentsRoute = id => `${API_ROOT}/posts/${id}/comment`;
+export const createCommentRoute = getCommentsRoute;

--- a/frontend/src/services/createPostService.js
+++ b/frontend/src/services/createPostService.js
@@ -1,3 +1,5 @@
+import { getPostsRoute } from './apiRoutes';
+
 /* eslint-disable no-underscore-dangle */
 export class SubmitPostError extends Error {}
 
@@ -9,7 +11,7 @@ export default async (title, body) => {
 
   const requestBody = JSON.stringify(parameters);
 
-  const response = await fetch('/posts', {
+  const response = await fetch(getPostsRoute, {
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',

--- a/frontend/src/services/createPostService.test.js
+++ b/frontend/src/services/createPostService.test.js
@@ -1,11 +1,9 @@
-import sinon from 'sinon';
 import { enableFetchMocks } from 'jest-fetch-mock';
+import submitPost from './createPostService';
+import { createPostRoute } from './apiRoutes';
 
 // Ensure that things are mocked before we import the implementation-under-test.
 enableFetchMocks();
-
-// eslint-disable-next-line import/first
-import submitPost from './createPostService';
 
 process.on('unhandledRejection', up => {
   throw up;
@@ -18,7 +16,7 @@ describe('submitPost', () => {
       statusText: 'OK',
     });
     await submitPost('title', 'body');
-    expect(fetch.mock.calls[0][0]).toEqual('/posts');
+    expect(fetch.mock.calls[0][0]).toEqual(createPostRoute);
     expect(fetch.mock.calls[0][1].method).toEqual('POST');
   });
 

--- a/frontend/src/services/frontpageService.jsx
+++ b/frontend/src/services/frontpageService.jsx
@@ -1,5 +1,7 @@
+import { upvotePostRoute, getPostsRoute } from './apiRoutes';
+
 export const getPosts = async () => {
-  const response = await fetch('/posts').then(respose => respose.json());
+  const response = await fetch(getPostsRoute).then(respose => respose.json());
   return response;
 };
 
@@ -13,7 +15,7 @@ export const handleVote = async ({ id, upvote_type, upvote }) => {
 
   const requestBody = JSON.stringify(params);
 
-  const response = await fetch(`/posts/${id}/upvote`, {
+  const response = await fetch(upvotePostRoute(id), {
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',

--- a/frontend/src/services/postDetailService.js
+++ b/frontend/src/services/postDetailService.js
@@ -1,8 +1,10 @@
+import { getPostRoute, createCommentRoute } from './apiRoutes';
+
 /* eslint-disable camelcase */
 export class SubmitCommentError extends Error {}
 
 export const getPostInformation = async postId => {
-  return fetch(`/posts/${postId}`).then(respose => respose.json());
+  return fetch(getPostRoute(postId)).then(respose => respose.json());
 };
 
 export default async (children_id, body) => {
@@ -15,7 +17,7 @@ export default async (children_id, body) => {
 
   const requestBody = JSON.stringify(parameters);
 
-  const response = await fetch(`/posts/${children_id}/comment`, {
+  const response = await fetch(createCommentRoute(children_id), {
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',


### PR DESCRIPTION
See #90 

## Proposed Changes

  - Move API route constants to a separate file 
  - Rename PostDetailService to follow naming convention of other services
  - Update routes so that they reflect the API specification
